### PR TITLE
Fix Heka message parser backtracking

### DIFF
--- a/telemetry/util/heka_message.py
+++ b/telemetry/util/heka_message.py
@@ -165,7 +165,6 @@ def read_one_record(input_stream, raw=False, verbose=False, strict=False, try_sn
         if verbose:
             print "Skipped", skipped, "bytes to find a valid separator"
 
-    #print "position", input_stream.tell()
     raw_record = struct.pack("<B", 0x1e)
 
     # Read the header length
@@ -195,7 +194,6 @@ def read_one_record(input_stream, raw=False, verbose=False, strict=False, try_sn
         raise DecodeError("Unexpected unit separator character in record at offset {}: {}".format(total_bytes, ord(unit_separator[0])))
     raw_record += unit_separator
 
-    #print "message length:", header.message_length
     message_raw = input_stream.read(header.message_length)
 
     total_bytes += header.message_length

--- a/telemetry/util/test_heka_message.py
+++ b/telemetry/util/test_heka_message.py
@@ -64,7 +64,7 @@ class TestHekaMessage(unittest.TestCase):
         w = hm.BacktrackableFile(StringIO("FOOBAR\x1eFOOBAR"))
         self.assertEquals("FOOBAR\x1eFOO", w.read(10))
         w.backtrack()
-        self.assertEquals("\x1eFOOBAR", w.read(10))
+        self.assertEquals("FOOBAR", w.read(10))
 
     def test_backtracking_without_separator(self):
         # Test backtracking when separator wasn't read

--- a/telemetry/util/test_heka_message.py
+++ b/telemetry/util/test_heka_message.py
@@ -6,8 +6,7 @@ import os
 import shutil
 import unittest
 import json
-#import telemetry.util.heka_message as hm
-import heka_message as hm
+import telemetry.util.heka_message as hm
 
 from cStringIO import StringIO
 

--- a/telemetry/util/test_heka_message.py
+++ b/telemetry/util/test_heka_message.py
@@ -6,7 +6,8 @@ import os
 import shutil
 import unittest
 import json
-import telemetry.util.heka_message as hm
+#import telemetry.util.heka_message as hm
+import heka_message as hm
 
 from cStringIO import StringIO
 
@@ -56,23 +57,31 @@ class TestHekaMessage(unittest.TestCase):
         # Test backtracking when the separator appears at the first character
         w = hm.BacktrackableFile(StringIO("\x1eFOOBAR"))
         self.assertEquals("\x1eFOOB", w.read(5))
+        self.assertEquals(w.tell(), 5)
         w.backtrack()
         self.assertEquals("AR", w.read(5))
+        self.assertEquals(w.tell(), 7)
 
     def test_backtracking_with_mid_separator(self):
         # Test backtracking when separator was read
         w = hm.BacktrackableFile(StringIO("FOOBAR\x1eFOOBAR"))
         self.assertEquals("FOOBAR\x1eFOO", w.read(10))
+        self.assertEquals(w.tell(), 10)
         w.backtrack()
         self.assertEquals("FOOBAR", w.read(10))
+        self.assertEquals(w.tell(), 13)
 
     def test_backtracking_without_separator(self):
         # Test backtracking when separator wasn't read
         w = hm.BacktrackableFile(StringIO("FOOBAR\x1eFOOBAR"))
         self.assertEquals("FOOBA", w.read(5))
-        w.backtrack()
+        self.assertEquals(w.tell(), 5)
+        w.backtrack() # doesn't do anything, because we haven't read the separator yet
+        self.assertEquals(w.tell(), 5)
         self.assertEquals("R\x1eFOO", w.read(5))
+        self.assertEquals(w.tell(), 10)
         self.assertEquals("BAR", w.read(5))
+        self.assertEquals(w.tell(), 13)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Heka message parsing failed due to an off-by-one error in `BacktrackableFile` - it backtracked one byte too far, which means none of the backtracked tries would ever work. This is trivially fixed.
- Error checking in non-strict mode was too lenient, and caused us to attempt to parse messages when we should have continued backtracking. We now check both the record separator and the unit separator.
  - Note that this also doesn't catch 100% of the cases, but it is off by less than 0.1%.
- Adding `BacktrackableFile.tell()`, which is really useful for debugging parsing errors like this in the future.

Ref: https://bugzilla.mozilla.org/show_bug.cgi?id=1248845

Here's a [notebook showing the debugging and testing process](https://gist.github.com/Uberi/a3a92bb011c7f3b0e8dc677c91471a10). The results seem to match up with expectations.
